### PR TITLE
Pass engine_args to create_engine in get_embedding_column_definition

### DIFF
--- a/tidb_vector/integrations/utils.py
+++ b/tidb_vector/integrations/utils.py
@@ -21,9 +21,9 @@ class EmbeddingColumnMismatchError(ValueError):
 
 
 def check_table_existence(
-    connection_string: str,
-    table_name: str,
-    engine_args: Optional[Dict[str, Any]] = None,
+        connection_string: str,
+        table_name: str,
+        engine_args: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     Check if the vector table exists in the database
@@ -44,7 +44,12 @@ def check_table_existence(
         engine.dispose()
 
 
-def get_embedding_column_definition(connection_string, table_name, column_name):
+def get_embedding_column_definition(
+        connection_string: str,
+        table_name: str,
+        column_name: str,
+        engine_args: Optional[Dict[str, Any]] = None,
+):
     """
     Retrieves the column definition of an embedding column from a database table.
 
@@ -52,11 +57,12 @@ def get_embedding_column_definition(connection_string, table_name, column_name):
         connection_string (str): The connection string to the database.
         table_name (str): The name of the table.
         column_name (str): The name of the column.
+        engine_args (Optional[Dict[str, Any]]): Additional arguments for the engine.
 
     Returns:
         tuple: A tuple containing the dimension (int or None) and distance metric (str or None).
     """
-    engine = sqlalchemy.create_engine(connection_string)
+    engine = sqlalchemy.create_engine(connection_string, **(engine_args or {}))
     try:
         with engine.connect() as connection:
             query = f"""SELECT COLUMN_TYPE, COLUMN_COMMENT

--- a/tidb_vector/integrations/utils.py
+++ b/tidb_vector/integrations/utils.py
@@ -21,9 +21,9 @@ class EmbeddingColumnMismatchError(ValueError):
 
 
 def check_table_existence(
-        connection_string: str,
-        table_name: str,
-        engine_args: Optional[Dict[str, Any]] = None,
+    connection_string: str,
+    table_name: str,
+    engine_args: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     Check if the vector table exists in the database
@@ -45,10 +45,10 @@ def check_table_existence(
 
 
 def get_embedding_column_definition(
-        connection_string: str,
-        table_name: str,
-        column_name: str,
-        engine_args: Optional[Dict[str, Any]] = None,
+    connection_string: str,
+    table_name: str,
+    column_name: str,
+    engine_args: Optional[Dict[str, Any]] = None,
 ):
     """
     Retrieves the column definition of an embedding column from a database table.

--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -25,9 +25,9 @@ class DistanceStrategy(str, enum.Enum):
 
 
 def _create_vector_table_model(
-    table_name: str,
-    dim: Optional[int] = None,
-    distance: Optional[DistanceStrategy] = None,
+        table_name: str,
+        dim: Optional[int] = None,
+        distance: Optional[DistanceStrategy] = None,
 ) -> Tuple[Type[declarative_base], Type]:
     """Create a vector model class."""
 
@@ -76,15 +76,15 @@ class QueryResult:
 
 class TiDBVectorClient:
     def __init__(
-        self,
-        connection_string: str,
-        table_name: str,
-        distance_strategy: Optional[DistanceStrategy] = None,
-        vector_dimension: Optional[int] = None,
-        *,
-        engine_args: Optional[Dict[str, Any]] = None,
-        drop_existing_table: bool = False,
-        **kwargs: Any,
+            self,
+            connection_string: str,
+            table_name: str,
+            distance_strategy: Optional[DistanceStrategy] = None,
+            vector_dimension: Optional[int] = None,
+            *,
+            engine_args: Optional[Dict[str, Any]] = None,
+            drop_existing_table: bool = False,
+            **kwargs: Any,
     ) -> None:
         """
         Initializes a vector client in a specified table within a TiDB database.
@@ -126,7 +126,10 @@ class TiDBVectorClient:
             return
 
         actual_dim, actual_distance_strategy = get_embedding_column_definition(
-            self.connection_string, self._table_name, "embedding"
+            connection_string=self.connection_string,
+            table_name=self._table_name,
+            column_name="embedding",
+            engine_args=self._engine_args,
         )
         if actual_dim is not None:
             # If the vector dimension is not set, set it to the actual dimension
@@ -197,12 +200,12 @@ class TiDBVectorClient:
             )
 
     def insert(
-        self,
-        texts: Iterable[str],
-        embeddings: Iterable[List[float]],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
+            self,
+            texts: Iterable[str],
+            embeddings: Iterable[List[float]],
+            metadatas: Optional[List[dict]] = None,
+            ids: Optional[List[str]] = None,
+            **kwargs: Any,
     ) -> List[str]:
         """
         Add texts to TiDB Vector.
@@ -236,10 +239,10 @@ class TiDBVectorClient:
         return ids
 
     def delete(
-        self,
-        ids: Optional[List[str]] = None,
-        filter: Optional[dict] = None,
-        **kwargs: Any,
+            self,
+            ids: Optional[List[str]] = None,
+            filter: Optional[dict] = None,
+            **kwargs: Any,
     ) -> None:
         """
         Delete vector data from the TiDB vector.
@@ -257,11 +260,11 @@ class TiDBVectorClient:
             session.commit()
 
     def query(
-        self,
-        query_vector: List[float],
-        k: int = 5,
-        filter: Optional[dict] = None,
-        **kwargs: Any,
+            self,
+            query_vector: List[float],
+            k: int = 5,
+            filter: Optional[dict] = None,
+            **kwargs: Any,
     ) -> List[QueryResult]:
         """
         Perform a similarity search with score based on the given query.
@@ -289,10 +292,10 @@ class TiDBVectorClient:
         ]
 
     def _vector_search(
-        self,
-        query_embedding: List[float],
-        k: int = 5,
-        filter: Optional[Dict[str, str]] = None,
+            self,
+            query_embedding: List[float],
+            k: int = 5,
+            filter: Optional[Dict[str, str]] = None,
     ) -> List[Any]:
         """vector search from table."""
 
@@ -365,8 +368,8 @@ class TiDBVectorClient:
                         filter_clauses.append(filter_by_metadata)
                 else:
                     filter_by_metadata = (
-                        sqlalchemy.func.json_extract(self._table_model.meta, f"$.{key}")
-                        == value
+                            sqlalchemy.func.json_extract(self._table_model.meta, f"$.{key}")
+                            == value
                     )
                     filter_clauses.append(filter_by_metadata)
 

--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -25,9 +25,9 @@ class DistanceStrategy(str, enum.Enum):
 
 
 def _create_vector_table_model(
-        table_name: str,
-        dim: Optional[int] = None,
-        distance: Optional[DistanceStrategy] = None,
+    table_name: str,
+    dim: Optional[int] = None,
+    distance: Optional[DistanceStrategy] = None,
 ) -> Tuple[Type[declarative_base], Type]:
     """Create a vector model class."""
 
@@ -76,15 +76,15 @@ class QueryResult:
 
 class TiDBVectorClient:
     def __init__(
-            self,
-            connection_string: str,
-            table_name: str,
-            distance_strategy: Optional[DistanceStrategy] = None,
-            vector_dimension: Optional[int] = None,
-            *,
-            engine_args: Optional[Dict[str, Any]] = None,
-            drop_existing_table: bool = False,
-            **kwargs: Any,
+        self,
+        connection_string: str,
+        table_name: str,
+        distance_strategy: Optional[DistanceStrategy] = None,
+        vector_dimension: Optional[int] = None,
+        *,
+        engine_args: Optional[Dict[str, Any]] = None,
+        drop_existing_table: bool = False,
+        **kwargs: Any,
     ) -> None:
         """
         Initializes a vector client in a specified table within a TiDB database.
@@ -200,12 +200,12 @@ class TiDBVectorClient:
             )
 
     def insert(
-            self,
-            texts: Iterable[str],
-            embeddings: Iterable[List[float]],
-            metadatas: Optional[List[dict]] = None,
-            ids: Optional[List[str]] = None,
-            **kwargs: Any,
+        self,
+        texts: Iterable[str],
+        embeddings: Iterable[List[float]],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> List[str]:
         """
         Add texts to TiDB Vector.
@@ -239,10 +239,10 @@ class TiDBVectorClient:
         return ids
 
     def delete(
-            self,
-            ids: Optional[List[str]] = None,
-            filter: Optional[dict] = None,
-            **kwargs: Any,
+        self,
+        ids: Optional[List[str]] = None,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
     ) -> None:
         """
         Delete vector data from the TiDB vector.
@@ -260,11 +260,11 @@ class TiDBVectorClient:
             session.commit()
 
     def query(
-            self,
-            query_vector: List[float],
-            k: int = 5,
-            filter: Optional[dict] = None,
-            **kwargs: Any,
+        self,
+        query_vector: List[float],
+        k: int = 5,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
     ) -> List[QueryResult]:
         """
         Perform a similarity search with score based on the given query.
@@ -292,10 +292,10 @@ class TiDBVectorClient:
         ]
 
     def _vector_search(
-            self,
-            query_embedding: List[float],
-            k: int = 5,
-            filter: Optional[Dict[str, str]] = None,
+        self,
+        query_embedding: List[float],
+        k: int = 5,
+        filter: Optional[Dict[str, str]] = None,
     ) -> List[Any]:
         """vector search from table."""
 
@@ -368,8 +368,8 @@ class TiDBVectorClient:
                         filter_clauses.append(filter_by_metadata)
                 else:
                     filter_by_metadata = (
-                            sqlalchemy.func.json_extract(self._table_model.meta, f"$.{key}")
-                            == value
+                        sqlalchemy.func.json_extract(self._table_model.meta, f"$.{key}")
+                        == value
                     )
                     filter_clauses.append(filter_by_metadata)
 


### PR DESCRIPTION
Pass engine_args to create_engine in get_embedding_column_definition.

Encountered this error when connecting to tidbcloud serverless cluster:

`sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (2003, "Can't connect to MySQL server on 'gateway01.eu-central-1.prod.aws.tidbcloud.com' ([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000))")`