### PR TITLE
deprecate vector<float>

### DIFF
--- a/tests/integrations/test_utils.py
+++ b/tests/integrations/test_utils.py
@@ -6,7 +6,7 @@ from tidb_vector.integrations.utils import extract_info_from_column_definition
 
 def test_extract_info_from_column_definition():
     # Test case with dimension and distance metric
-    column_type = "VECTOR<FLOAT>(128)"
+    column_type = "VECTOR(128)"
     column_comment = "hnsw(distance=cosine)"
     expected_result = (128, "cosine")
     assert (
@@ -15,7 +15,7 @@ def test_extract_info_from_column_definition():
     )
 
     # Test case with dimension but no distance metric
-    column_type = "VECTOR<FLOAT>(256)"
+    column_type = "VECTOR(256)"
     column_comment = "some comment"
     expected_result = (256, None)
     assert (
@@ -24,7 +24,7 @@ def test_extract_info_from_column_definition():
     )
 
     # Test case with no dimension and no distance metric
-    column_type = "VECTOR<FLOAT>"
+    column_type = "VECTOR"
     column_comment = "another comment"
     expected_result = (None, None)
     assert (
@@ -33,7 +33,7 @@ def test_extract_info_from_column_definition():
     )
 
     # Test case with no dimension and no comment
-    column_type = "VECTOR<FLOAT>"
+    column_type = "VECTOR"
     column_comment = ""
     expected_result = (None, None)
     assert (
@@ -42,7 +42,7 @@ def test_extract_info_from_column_definition():
     )
 
     # Test case with dimension but no comment
-    column_type = "VECTOR<FLOAT>(256)"
+    column_type = "VECTOR(256)"
     column_comment = ""
     expected_result = (256, None)
     assert (
@@ -51,7 +51,7 @@ def test_extract_info_from_column_definition():
     )
 
     # Test case without index type
-    column_type = "VECTOR<FLOAT>"
+    column_type = "VECTOR"
     column_comment = "distance=l2"
     expected_result = (None, "l2")
     assert (
@@ -60,7 +60,7 @@ def test_extract_info_from_column_definition():
     )
 
     # Test case with addition comment content
-    column_type = "VECTOR<FLOAT>(128)"
+    column_type = "VECTOR(128)"
     column_comment = "test, hnsw(distance=l2)"
     expected_result = (128, "l2")
     assert (

--- a/tidb_vector/integrations/utils.py
+++ b/tidb_vector/integrations/utils.py
@@ -89,9 +89,7 @@ def extract_info_from_column_definition(column_type, column_comment):
         tuple: A tuple containing the dimension (int or None) and the distance metric (str or None).
     """
     # Try to extract the dimension, which is optional.
-    dimension_match = re.search(
-        r"VECTOR(?:\((\d+)\))?", column_type, re.IGNORECASE
-    )
+    dimension_match = re.search(r"VECTOR(?:\((\d+)\))?", column_type, re.IGNORECASE)
     dimension = (
         int(dimension_match.group(1))
         if dimension_match and dimension_match.group(1)

--- a/tidb_vector/integrations/utils.py
+++ b/tidb_vector/integrations/utils.py
@@ -90,7 +90,7 @@ def extract_info_from_column_definition(column_type, column_comment):
     """
     # Try to extract the dimension, which is optional.
     dimension_match = re.search(
-        r"VECTOR<FLOAT>(?:\((\d+)\))?", column_type, re.IGNORECASE
+        r"VECTOR(?:\((\d+)\))?", column_type, re.IGNORECASE
     )
     dimension = (
         int(dimension_match.group(1))

--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -137,8 +137,8 @@ class TiDBVectorClient:
                 self._vector_dimension = actual_dim
             elif actual_dim != self._vector_dimension:
                 raise EmbeddingColumnMismatchError(
-                    existing_col=f"vector<float>({actual_dim})",
-                    expected_col=f"vector<float>({self._vector_dimension})",
+                    existing_col=f"vector({actual_dim})",
+                    expected_col=f"vector({self._vector_dimension})",
                 )
 
         if actual_distance_strategy is not None:
@@ -146,8 +146,8 @@ class TiDBVectorClient:
                 self._distance_strategy = DistanceStrategy(actual_distance_strategy)
             elif actual_distance_strategy != self._distance_strategy:
                 raise EmbeddingColumnMismatchError(
-                    existing_col=f"vector<float>({actual_dim}) COMMENT 'hnsw(distance={actual_distance_strategy})'",
-                    expected_col=f"vector<float>({self._vector_dimension}) COMMENT 'hnsw(distance={self._distance_strategy})'",
+                    existing_col=f"vector({actual_dim}) COMMENT 'hnsw(distance={actual_distance_strategy})'",
+                    expected_col=f"vector({self._vector_dimension}) COMMENT 'hnsw(distance={self._distance_strategy})'",
                 )
 
     def _create_table_if_not_exists(self) -> None:

--- a/tidb_vector/peewee/__init__.py
+++ b/tidb_vector/peewee/__init__.py
@@ -4,7 +4,7 @@ from tidb_vector.utils import decode_vector, encode_vector
 
 
 class VectorField(Field):
-    field_type = "VECTOR<FLOAT>"
+    field_type = "VECTOR"
 
     def __init__(self, dimensions=None, *args, **kwargs):
         self.dimensions = dimensions

--- a/tidb_vector/sqlalchemy/__init__.py
+++ b/tidb_vector/sqlalchemy/__init__.py
@@ -31,7 +31,7 @@ class VectorType(UserDefinedType):
         """
         Returns the column specification for the vector column.
 
-        If the dimension is not specified, it returns "VECTOR<FLOAT>".
+        If the dimension is not specified, it returns "VECTOR".
         Otherwise, it returns "VECTOR(<dimension>)".
 
         :param kw: Additional keyword arguments.
@@ -39,8 +39,8 @@ class VectorType(UserDefinedType):
         """
 
         if self.dim is None:
-            return "VECTOR<FLOAT>"
-        return "VECTOR<FLOAT>(%d)" % self.dim
+            return "VECTOR"
+        return "VECTOR(%d)" % self.dim
 
     def bind_processor(self, dialect):
         """Convert the vector float array to a string representation suitable for binding to a database column."""


### PR DESCRIPTION
Creating a table with `VECTOR<FLOAT>` is no longer recommended, this pr use `VECTOR` instead.

However, TiDB still returns `VECTOR<FLOAT>` in the results of "show create table" and "INFORMATION_SCHEMA.COLUMNS". Therefore, we need to maintain the test cases with the old syntax.