### PR TITLE
Add post filter workaround logic for tidb vector search performance?

### DIFF
--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -274,7 +274,7 @@ class TiDBVectorClient:
             k (int, optional): The number of results to return. Defaults to 5.
             filter (dict, optional): A filter to apply to the search results.
                 Defaults to None.
-            post_filter_enabled (bool, optional): Whether to apply the post-filtering.
+            post_filter_enabled (bool, optional): Whether to apply the post-filtering. TiDB cannot utilize Vector Index when query contains a pre-filter.
             post_filter_multiplier (int, optional): A multiplier to increase the initial
                 number of results fetched before applying the filter. Defaults to 1.
             **kwargs: Additional keyword arguments.

--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -323,7 +323,7 @@ class TiDBVectorClient:
             else:
                 # Caused by the tidb vector search plan limited, this post_filter_multiplier is used to
                 # improved the search performance temporarily.
-                # Notice the return count may be less than k in this sutiation.
+                # Notice the return count may be less than k in this situation.
                 subquery = (
                     session.query(
                         self._table_model.id,

--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -274,7 +274,8 @@ class TiDBVectorClient:
             k (int, optional): The number of results to return. Defaults to 5.
             filter (dict, optional): A filter to apply to the search results.
                 Defaults to None.
-            post_filter_enabled (bool, optional): Whether to apply the post-filtering. TiDB cannot utilize Vector Index when query contains a pre-filter.
+            post_filter_enabled (bool, optional): Whether to apply the post-filtering.
+                TiDB cannot utilize Vector Index when query contains a pre-filter.
             post_filter_multiplier (int, optional): A multiplier to increase the initial
                 number of results fetched before applying the filter. Defaults to 1.
             **kwargs: Additional keyword arguments.

--- a/tidb_vector/integrations/vector_client.py
+++ b/tidb_vector/integrations/vector_client.py
@@ -306,7 +306,7 @@ class TiDBVectorClient:
         post_filter_enabled = kwargs.get("post_filter_enabled", False)
         post_filter_multiplier = kwargs.get("post_filter_multiplier", 1)
         with Session(self._bind) as session:
-            if post_filter_enabled is False or filter is None:
+            if post_filter_enabled is False or not filter:
                 filter_by = self._build_filter_clause(filter)
                 results: List[Any] = (
                     session.query(


### PR DESCRIPTION
It's a workaround for TiDB Vector search execution plan limitation: the where condition will cause the vector index disabled while searching.

No recommand to set  post_filter_enabled and post_filter_multiplier, but It can be used to workaround while encountering some performance issue.