### PR TITLE
fix: add python-dotenv to requirements in Python client Quickstart

### DIFF
--- a/examples/python-client-quickstart/requirements.txt
+++ b/examples/python-client-quickstart/requirements.txt
@@ -1,3 +1,4 @@
+python-dotenv==1.0.0
 PyMySQL==1.1.0
 sentence-transformers==3.0.1
 SQLAlchemy==2.0.30

--- a/examples/python-client-quickstart/requirements.txt
+++ b/examples/python-client-quickstart/requirements.txt
@@ -1,3 +1,4 @@
+mysqlclient==2.2.4
 python-dotenv==1.0.0
 PyMySQL==1.1.0
 sentence-transformers==3.0.1


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "python-client-quickstart/example.py", line 4, in <module>
    from dotenv import load_dotenv
ModuleNotFoundError: No module named 'dotenv'
```