### PR TITLE
fix: remove mysqlclient dep for quickstart

### DIFF
--- a/examples/python-client-quickstart/requirements.txt
+++ b/examples/python-client-quickstart/requirements.txt
@@ -1,4 +1,3 @@
-mysqlclient==2.2.4
 python-dotenv==1.0.0
 PyMySQL==1.1.0
 sentence-transformers==3.0.1


### PR DESCRIPTION
Avoids the need for users to install pkg-config, mysql-client dependencies on their operating system. PyMySQL is a pure Python impl of mysql client.